### PR TITLE
Add support for Avro schema fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ those changes.
 Originally, we were waiting in hope the elodina maintainer would return, but it
 hasn't happened, so the plan now is to proceed with this as its own library and
 take PRs, push for feature additions and version bumps.
+

--- a/artisanal_json.go
+++ b/artisanal_json.go
@@ -1,0 +1,32 @@
+package avro
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+)
+
+/*
+ * this file contains a bunch of helper methods for writing bespoke JSON marshal functions.
+ */
+
+func writeFieldName(buf *bytes.Buffer, fieldname string, precedingComma bool) {
+	if precedingComma {
+		buf.WriteRune(',')
+	}
+	buf.WriteRune('"')
+	buf.WriteString(fieldname)
+	buf.WriteRune('"')
+	buf.WriteRune(':')
+}
+
+func writeInt(buf *bytes.Buffer, fieldname string, value int, precedingComma bool) {
+	writeFieldName(buf, fieldname, precedingComma)
+	buf.WriteString(strconv.FormatInt(int64(value), 10))
+}
+
+func writeString(buf *bytes.Buffer, fieldname, value string, precedingComma bool) {
+	writeFieldName(buf, fieldname, precedingComma)
+	formatted, _ := json.Marshal(value)
+	buf.Write(formatted)
+}

--- a/datum_writer.go
+++ b/datum_writer.go
@@ -162,8 +162,7 @@ func (writer *SpecificDatumWriter) writeLong(v reflect.Value, enc Encoder, s Sch
 	if !s.Validate(v) {
 		return fmt.Errorf("Invalid long value: %v", v.Interface())
 	}
-
-	enc.WriteLong(v.Interface().(int64))
+	enc.WriteLong(s.(*LongSchema).GetInt64(v))
 	return nil
 }
 

--- a/datum_writer_test.go
+++ b/datum_writer_test.go
@@ -259,7 +259,7 @@ func TestSpecificDatumWriterLogicalTypes(t *testing.T) {
 	in := &Logical{
 		TimeMillis:      time.Unix(123456, int64(789*time.Millisecond)),
 		TimeMicros:      time.Unix(1234567890, int64(123456*time.Microsecond)),
-		TimeOfDayMicros: time.Unix(1234509876, int64(543210*time.Microsecond)),
+		TimeOfDayMicros: time.Unix(1234509876, int64(543210*time.Microsecond)).UTC(),
 	}
 
 	err = w.Write(in, enc)

--- a/errors.go
+++ b/errors.go
@@ -39,6 +39,12 @@ var ErrBlockNotFinished = errors.New("Block read is unfinished")
 // Happens when avro schema contains invalid value for fixed size.
 var ErrInvalidFixedSize = errors.New("Invalid Fixed type size")
 
+// Happens when logicalType = decimal, but no precision specified
+var ErrPrecisionRequired = errors.New("precision is required in decimal logicalType")
+
+// Happens when avro schema contains invalid value for map value type or array item type.
+var ErrInvalidValueType = errors.New("Invalid array or map value type")
+
 //// Happens when avro schema contains a union within union.
 //var ErrNestedUnionsNotAllowed = errors.New("Nested unions are not allowed")
 

--- a/schema.go
+++ b/schema.go
@@ -203,18 +203,30 @@ func (bs *BytesSchema) MarshalJSON() ([]byte, error) {
 	if bs.LogicalType == "" {
 		return []byte(`"bytes"`), nil
 	}
-	// the only logical type on bytes is decimal
-	return json.Marshal(struct {
-		Type        string `json:"type"`
-		LogicalType string `json:"logicalType"`
-		Scale       int    `json:"scale"`
-		Precision   int    `json:"precision"`
-	}{
-		Type:        "long",
-		LogicalType: bs.LogicalType,
-		Scale:       bs.Scale,
-		Precision:   bs.Precision,
-	})
+	if bs.LogicalType == logicalTypeDecimal {
+		// the only logical type on bytes is decimal
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			LogicalType string `json:"logicalType"`
+			Scale       int    `json:"scale"`
+			Precision   int    `json:"precision"`
+		}{
+			Type:        "bytes",
+			LogicalType: bs.LogicalType,
+			Scale:       bs.Scale,
+			Precision:   bs.Precision,
+		})
+	} else {
+		// otherwise who knows?
+		// the only logical type on bytes is decimal
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			LogicalType string `json:"logicalType"`
+		}{
+			Type:        "bytes",
+			LogicalType: bs.LogicalType,
+		})
+	}
 }
 
 // IntSchema implements Schema and represents Avro int type.

--- a/schema_test.go
+++ b/schema_test.go
@@ -35,6 +35,7 @@ func TestArraySchema(t *testing.T) {
 	if s.(*ArraySchema).Items.Type() != String {
 		t.Errorf("\n%s \n===\n Array item type should be STRING", raw)
 	}
+	stringArrayFingerprint := s.Fingerprint()
 
 	//array of longs
 	raw = `{"type":"array", "items": "long"}`
@@ -45,6 +46,9 @@ func TestArraySchema(t *testing.T) {
 	}
 	if s.(*ArraySchema).Items.Type() != Long {
 		t.Errorf("\n%s \n===\n Array item type should be LONG", raw)
+	}
+	if s.Fingerprint() == stringArrayFingerprint {
+		t.Errorf("\n%x \n===\n %x different schemas should have different fingerprints", stringArrayFingerprint, s.Fingerprint())
 	}
 
 	//array of arrays of strings
@@ -59,6 +63,9 @@ func TestArraySchema(t *testing.T) {
 	}
 	if s.(*ArraySchema).Items.(*ArraySchema).Items.Type() != String {
 		t.Errorf("\n%s \n===\n Array's nested item type should be STRING", raw)
+	}
+	if s.(*ArraySchema).Items.Fingerprint() != stringArrayFingerprint {
+		t.Errorf("\n%x \n!==\n %x matching schemas should have matching fingerprints", s.(*ArraySchema).Items.Fingerprint(), stringArrayFingerprint)
 	}
 
 	raw = `{"type":"array", "items": {"type": "record", "name": "TestRecord", "fields": [
@@ -256,6 +263,12 @@ func TestFixedSchema(t *testing.T) {
 	}
 	if s.(*FixedSchema).Name != "md5" {
 		t.Errorf("\n%s \n===\n Fixed name should be md5. Actual %#v", raw, s.(*FixedSchema).Name)
+	}
+	md5fingerprint := s.Fingerprint()
+	s, err = ParseSchema(`{"type": "fixed", "doc": "md5 is a digest of an input message", "size": 16, "name": "md5"}`)
+	assert(t, err, nil)
+	if s.Fingerprint() != md5fingerprint {
+		t.Errorf("\n%x \n!==\n %x matching schemas should have matching fingerprints", s.Fingerprint(), md5fingerprint)
 	}
 }
 


### PR DESCRIPTION
Some support for getting canonical schemas and CRC64 fingerprints out of Avro schemas.  See [Canonical Form for Schemas](https://avro.apache.org/docs/1.8.2/spec.html#Parsing+Canonical+Form+for+Schemas) for more.