### PR TITLE
Make newDataFileReader public, using IoReader

### DIFF
--- a/data_file.go
+++ b/data_file.go
@@ -90,7 +90,7 @@ func NewDataFileReader(filename string, ignoreMe ...DatumReader) (*DataFileReade
 		return nil, err
 	}
 
-	reader, err := newDataFileReader(f)
+	reader, err := NewDataFileReader_IoReader(f)
 	if err != nil {
 		// If there's any decoding issues, try not leaking a file handle.
 		f.Close()
@@ -99,7 +99,7 @@ func NewDataFileReader(filename string, ignoreMe ...DatumReader) (*DataFileReade
 
 }
 
-func newDataFileReader(input io.Reader) (reader *DataFileReader, err error) {
+func NewDataFileReader_IoReader(input io.Reader) (reader *DataFileReader, err error) {
 	dec := NewBinaryDecoderReader(input) // Since dec doesn't buffer, we can share it.
 	reader = &DataFileReader{
 		sharedCopyBuf: make([]byte, 4096),

--- a/data_file_test.go
+++ b/data_file_test.go
@@ -47,7 +47,7 @@ func TestDataFileWriter(t *testing.T) {
 	assert(t, len(encoded), 1145)
 
 	// now make sure we can decode again
-	dfr, err := newDataFileReader(bytes.NewReader(encoded))
+	dfr, err := NewDataFileReader_IoReader(bytes.NewReader(encoded))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
There's a private function that we need to access publicly, parsing from a reader instead of a filename.